### PR TITLE
Add randomizeOnFirstJoin option to let players pick their first origin

### DIFF
--- a/src/main/java/quantumxenon/randomiser/config/OriginsRandomiserConfig.java
+++ b/src/main/java/quantumxenon/randomiser/config/OriginsRandomiserConfig.java
@@ -24,6 +24,8 @@ public class OriginsRandomiserConfig implements ConfigData {
         @ConfigEntry.Gui.Tooltip
         public boolean randomiseOrigins = true;
         @ConfigEntry.Gui.Tooltip
+        public boolean randomiseOnFirstJoin = true;
+        @ConfigEntry.Gui.Tooltip
         public boolean randomiserMessages = true;
         @ConfigEntry.Gui.Tooltip
         public boolean dropExtraInventory = true;

--- a/src/main/java/quantumxenon/randomiser/events/OriginsRandomiserEvents.java
+++ b/src/main/java/quantumxenon/randomiser/events/OriginsRandomiserEvents.java
@@ -10,7 +10,7 @@ import static quantumxenon.randomiser.utils.OriginUtils.config;
 public class OriginsRandomiserEvents {
     public static void firstJoin(ServerPlayerEntity player) {
         if (ScoreboardUtils.noScoreboardTag("firstJoin", player)) {
-            if (config.general.randomiseOrigins) {
+            if (config.general.randomiseOrigins && config.general.randomiseOnFirstJoin) {
                 OriginUtils.randomOrigin(Reason.FIRST_JOIN, player);
             }
         }

--- a/src/main/java/quantumxenon/randomiser/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/quantumxenon/randomiser/mixin/ServerPlayerEntityMixin.java
@@ -35,7 +35,7 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
             ScoreboardUtils.createObjective("sleepsUntilRandomise", config.other.sleepsBetweenRandomises, player);
             ScoreboardUtils.createObjective("uses", config.command.randomiseCommandUses, player);
             ScoreboardUtils.createObjective("lives", config.lives.startingLives, player);
-            if (config.general.randomiseOrigins) {
+            if (config.general.randomiseOrigins && config.general.randomiseOnFirstJoin) {
                 OriginUtils.randomOrigin(Reason.FIRST_JOIN, player);
             }
         }

--- a/src/main/resources/assets/origins-randomiser/lang/en_gb.json
+++ b/src/main/resources/assets/origins-randomiser/lang/en_gb.json
@@ -6,6 +6,8 @@
 	"text.autoconfig.origins-randomiser.option.other":"Other",
 	"text.autoconfig.origins-randomiser.option.general.randomiseOrigins":"randomiseOrigins",
 	"text.autoconfig.origins-randomiser.option.general.randomiseOrigins.@Tooltip":"Master toggle for origin randomisation",
+	"text.autoconfig.origins-randomiser.option.general.randomiseOnFirstJoin": "randomiseOnFirstJoin",
+	"text.autoconfig.origins-randomiser.option.general.randomiseOnFirstJoin.@Tooltip": "Toggle assigning a random origin on a player's first join",
 	"text.autoconfig.origins-randomiser.option.general.randomiserMessages":"randomiserMessages",
 	"text.autoconfig.origins-randomiser.option.general.randomiserMessages.@Tooltip":"Toggle global messages about a player's new origin",
 	"text.autoconfig.origins-randomiser.option.general.dropExtraInventory":"dropExtraInventory",

--- a/src/main/resources/assets/origins-randomiser/lang/en_us.json
+++ b/src/main/resources/assets/origins-randomiser/lang/en_us.json
@@ -6,6 +6,8 @@
 	"text.autoconfig.origins-randomiser.option.other":"Other",
 	"text.autoconfig.origins-randomiser.option.general.randomiseOrigins":"randomizeOrigins",
 	"text.autoconfig.origins-randomiser.option.general.randomiseOrigins.@Tooltip":"Master toggle for origin randomization",
+	"text.autoconfig.origins-randomiser.option.general.randomiseOnFirstJoin":"randomizeOnFirstJoin",
+	"text.autoconfig.origins-randomiser.option.general.randomiseOnFirstJoin.@Tooltip":"Toggle assigning a random origin on a player's first join",
 	"text.autoconfig.origins-randomiser.option.general.randomiserMessages":"randomizerMessages",
 	"text.autoconfig.origins-randomiser.option.general.randomiserMessages.@Tooltip":"Toggle global messages about a player's new origin",
 	"text.autoconfig.origins-randomiser.option.general.dropExtraInventory":"dropExtraInventory",


### PR DESCRIPTION
Added an option to toggle randomizing the origin on the first join. This will let players choose their first join.

Solves #9 

I'm working on a fabric modpack and we really need this. 😄 
